### PR TITLE
Fixed Flaky Test PositionalParametersStoredProcedureCallTest#testResultSetStaticCallRaw

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
@@ -151,8 +151,14 @@ public class PositionalParametersStoredProcedureCallTest extends OgmJpaTestCase 
 
 			List<?> listResult = storedProcedureQuery.getResultList();
 			assertThat( listResult ).hasSize( 2 );
-			assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 );
-			assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" );
+			for ( Object object : listResult ) {
+				if ( object instanceof Integer ) {
+					assertThat( (Integer) object ).isEqualTo( 2 );
+				}
+				else if ( object instanceof String ) {
+					assertThat( String.valueOf( object ) ).isEqualTo( "title'2" );
+				}
+			}
 		} );
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes a Flaky Test PositionalParametersStoredProcedureCallTest#testResultSetStaticCallRaw found by using the NonDex tool - https://github.com/TestingResearchIllinois/NonDex*

## Error in NonDex

```
[ERROR]   PositionalParametersStoredProcedureCallTest.testResultSetStaticCallRaw:145->OgmJpaTestCase.inTransaction:103->lambda$testResultSetStaticCallRaw$5:154 ClassCast
[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
Assertion error in line - assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 );
```

## Analysis of the error

- *The list listResult is an unbounded wildcard (List<?>). Which implies that the list can have entries of any kind. Hence, it is are not deterministic.*
- *The assert statement type casts the element at position 0 to a Number. But, there is no guarentee that the element at position 0 is a Number*
- *NonDx flags this as Flaky as the list with a String in the 0th position results in a class cast exception as they are not covariant.*
- *So, the assertions may fail in some scenarios as there is no guarentee of the order and type of values populated in the list.*

## Brief change log

Traversed through the list and used instanceof to check the type of data before the actual assertions.

In this way we are **not** assuming that the order in which data is returned by the unbounded wildcard list (and the datatype of the returned value) is constant.

## Errors faced during the execution 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin
```
Checkstyle library was giving an error because fixed test case file was not formatted according to the standards. 
Fix : went through checkstyle.xml and manually fixed the formatting issues

## Verifying this change

This change added tests and can be verified as follows:
```
git clone https://github.com/akshathsk/hibernate-ogm.git
cd hibernate-ogm
git checkout fix-flakyDnondexRuns=100 
mvn install -pl neo4j -am -DskipTests -Dcheckstyle.skip | tee ../../../logs/fork-neo4j-final.test11.0.log   #### Result : Build passed
mvn -pl neo4j test -Dtest=org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest#testResultSetStaticCallRaw | tee ../../../logs/fork-neo4j-final.test12.log    #### Result : Build passed
mvn -pl neo4j edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest#testResultSetStaticCallRaw -DnondexRuns=100 | tee ../../../logs/fork-neo4j.test14-final.log   #### Result : Build passed
```

## Documentation
  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
